### PR TITLE
Add line_item_ids parameter to get all promoted tweets

### DIFF
--- a/twitter4j-ads/src/twitter4jads/api/TwitterAdsPromotedTweetApi.java
+++ b/twitter4j-ads/src/twitter4jads/api/TwitterAdsPromotedTweetApi.java
@@ -29,7 +29,7 @@ public interface TwitterAdsPromotedTweetApi {
      * @return Retrieve references to the Promoted Tweets associated with one or more line items.
      * @see <a href="https://dev.twitter.com/ads/reference/get/accounts/%3Aaccount_id/promoted_tweets">https://dev.twitter.com/ads/reference/get/accounts/%3Aaccount_id/promoted_tweets</a>
      */
-    BaseAdsListResponseIterable<PromotedTweets> getAllPromotedTweets(String accountId, boolean withDeleted,
+    BaseAdsListResponseIterable<PromotedTweets> getAllPromotedTweets(String accountId, boolean withDeleted, Optional<Collection<String>> lineItemIds,
                                                                      Optional<Integer> count, String cursor, Optional<PromotedTweetsSortByField> sortByField) throws TwitterException;
 
 

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPromotedTweetApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPromotedTweetApiImpl.java
@@ -40,7 +40,7 @@ public class TwitterAdsPromotedTweetApiImpl implements TwitterAdsPromotedTweetAp
     }
 
     @Override
-    public BaseAdsListResponseIterable<PromotedTweets> getAllPromotedTweets(String accountId, boolean withDeleted,
+    public BaseAdsListResponseIterable<PromotedTweets> getAllPromotedTweets(String accountId, boolean withDeleted, Optional<Collection<String>> lineItemIds,
                                                                             Optional<Integer> count, String cursor, Optional<PromotedTweetsSortByField> sortByField) throws TwitterException {
         TwitterAdUtil.ensureNotNull(accountId, "accountId");
         List<HttpParameter> params = new ArrayList<>();
@@ -50,6 +50,10 @@ public class TwitterAdsPromotedTweetApiImpl implements TwitterAdsPromotedTweetAp
         }
         if (TwitterAdUtil.isNotNullOrEmpty(cursor)) {
             params.add(new HttpParameter(PARAM_CURSOR, cursor));
+        }
+        if (lineItemIds != null && lineItemIds.isPresent()) {
+            TwitterAdUtil.ensureMaxSize(lineItemIds.get(), MAX_REQUEST_PARAMETER_SIZE);
+            params.add(new HttpParameter(TwitterAdsConstants.PARAM_LINE_ITEM_IDS, TwitterAdUtil.getCsv(lineItemIds.get())));
         }
         if (sortByField != null && sortByField.isPresent()) {
             params.add(new HttpParameter(PARAM_SORT_BY, sortByField.get().getField()));


### PR DESCRIPTION
Add line_item_ids parameter to get all promoted tweets.

@galkoren  - please review & merge.

Thanks.