### PR TITLE
Fixed upload media url

### DIFF
--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -76,6 +76,8 @@ public interface TwitterAdsConstants {
     String PARAM_TARGET_CPA_LOCAL_MICRO = "target_cpa_local_micro";
     String PARAM_BID_TYPE = "bid_type";
     String PARAM_BID_UNIT = "bid_unit";
+
+    String PARAM_AUTOMATICALLY_SELECT_BID = "automatically_select_bid";
     String PARAM_OPTIMIZATION = "optimization";
     String PARAM_CHARGE_BY = "charge_by";
     String PARAM_PRODUCT_TYPE = "product_type";

--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -123,6 +123,7 @@ public interface TwitterAdsConstants {
     String PARAM_NEGATIVE_BEHAVIOR = "negative_behaviors";
     String PARAM_BEHAVIOR_EXPANDED = "behaviors_expanded";
     String PARAM_CARD_IDS = "card_ids";
+    String PARAM_CARD_ID = "card_id";
     String PARAM_IPHONE_APP_ID = "iphone_app_id";
     String PARAM_IPAD_APP_ID = "ipad_app_id";
     String PARAM_GOOGLEPLAY_APP_ID = "googleplay_app_id";

--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -125,6 +125,8 @@ public interface TwitterAdsConstants {
     String PARAM_NEGATIVE_BEHAVIOR = "negative_behaviors";
     String PARAM_BEHAVIOR_EXPANDED = "behaviors_expanded";
     String PARAM_CARD_IDS = "card_ids";
+
+    String PARAM_CARD_ID = "card_id";
     String PARAM_IPHONE_APP_ID = "iphone_app_id";
     String PARAM_IPAD_APP_ID = "ipad_app_id";
     String PARAM_GOOGLEPLAY_APP_ID = "googleplay_app_id";

--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -123,7 +123,6 @@ public interface TwitterAdsConstants {
     String PARAM_NEGATIVE_BEHAVIOR = "negative_behaviors";
     String PARAM_BEHAVIOR_EXPANDED = "behaviors_expanded";
     String PARAM_CARD_IDS = "card_ids";
-    String PARAM_CARD_ID = "card_id";
     String PARAM_IPHONE_APP_ID = "iphone_app_id";
     String PARAM_IPAD_APP_ID = "ipad_app_id";
     String PARAM_GOOGLEPLAY_APP_ID = "googleplay_app_id";

--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -125,8 +125,6 @@ public interface TwitterAdsConstants {
     String PARAM_NEGATIVE_BEHAVIOR = "negative_behaviors";
     String PARAM_BEHAVIOR_EXPANDED = "behaviors_expanded";
     String PARAM_CARD_IDS = "card_ids";
-
-    String PARAM_CARD_ID = "card_id";
     String PARAM_IPHONE_APP_ID = "iphone_app_id";
     String PARAM_IPAD_APP_ID = "ipad_app_id";
     String PARAM_GOOGLEPLAY_APP_ID = "googleplay_app_id";

--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -15,7 +15,7 @@ public interface TwitterAdsConstants {
     int TAILORED_AUDIENCE_UPDATE_BATCH_SIZE = 2500;
 
     String TWEET_PREVIEW_PATH = "/tweet/preview/";
-    String UPLOAD_MEDIA_URL = "1.1/media/";
+    String UPLOAD_MEDIA_URL = "media/";
     String UPLOAD_JSON = "upload.json";
     String PREFIX_BATCH_ACCOUNTS_V4 = "4/batch/accounts/";
     String V4_PREFIX_STATS_JOB_ACCOUNTS_URI = "4/stats/jobs/accounts/";

--- a/twitter4j-ads/src/twitter4jads/api/TwitterAdsCardsApi.java
+++ b/twitter4j-ads/src/twitter4jads/api/TwitterAdsCardsApi.java
@@ -1,6 +1,10 @@
 package twitter4jads.api;
 
+import java.io.IOException;
+import java.util.List;
+
 import com.google.common.base.Optional;
+
 import twitter4jads.BaseAdsListResponseIterable;
 import twitter4jads.BaseAdsResponse;
 import twitter4jads.internal.models4j.TwitterException;
@@ -15,9 +19,6 @@ import twitter4jads.models.ads.cards.TwitterVideoDMCard;
 import twitter4jads.models.ads.cards.TwitterVideoWebsiteCard;
 import twitter4jads.models.ads.cards.TwitterWebsiteCard;
 import twitter4jads.models.media.TwitterLibraryMedia;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * User: abhay
@@ -191,7 +192,8 @@ public interface TwitterAdsCardsApi {
      * @return details of the created card if successful
      * @throws TwitterException
      */
-    BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle, String websiteUrl, String imageMediaId)
+    BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle,
+            String websiteUrl, String imageMediaId, String userId)
         throws TwitterException;
 
     /**

--- a/twitter4j-ads/src/twitter4jads/api/TwitterAdsCardsApi.java
+++ b/twitter4j-ads/src/twitter4jads/api/TwitterAdsCardsApi.java
@@ -193,7 +193,7 @@ public interface TwitterAdsCardsApi {
      * @throws TwitterException
      */
     BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle,
-            String websiteUrl, String imageMediaId, String userId)
+            String websiteUrl, String imageMediaId)
         throws TwitterException;
 
     /**

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsCardsApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsCardsApiImpl.java
@@ -1,45 +1,9 @@
 package twitter4jads.impl;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.gson.reflect.TypeToken;
-import org.apache.commons.lang3.StringUtils;
-import twitter4jads.BaseAdsListResponse;
-import twitter4jads.BaseAdsListResponseIterable;
-import twitter4jads.BaseAdsResponse;
-import twitter4jads.TwitterAdsClient;
-import twitter4jads.TwitterAdsConstants;
-import twitter4jads.api.TwitterAdsCardsApi;
-import twitter4jads.internal.http.HttpParameter;
-import twitter4jads.internal.models4j.Media;
-import twitter4jads.internal.models4j.MediaUpload;
-import twitter4jads.internal.models4j.TwitterException;
-import twitter4jads.models.ads.HttpVerb;
-import twitter4jads.models.ads.TwitterUUIDResponse;
-import twitter4jads.models.ads.cards.AbstractConversationCard;
-import twitter4jads.models.ads.cards.TwitterImageAppDownloadCard;
-import twitter4jads.models.ads.cards.TwitterImageConversationCard;
-import twitter4jads.models.ads.cards.TwitterImageDMCard;
-import twitter4jads.models.ads.cards.TwitterLeadGenerationStat;
-import twitter4jads.models.ads.cards.TwitterMobileAppCard;
-import twitter4jads.models.ads.cards.TwitterVideoAppDownloadCard;
-import twitter4jads.models.ads.cards.TwitterVideoConversationCard;
-import twitter4jads.models.ads.cards.TwitterVideoDMCard;
-import twitter4jads.models.ads.cards.TwitterVideoWebsiteCard;
-import twitter4jads.models.ads.cards.TwitterWebsiteCard;
-import twitter4jads.models.media.TwitterLibraryMedia;
-import twitter4jads.util.TwitterAdUtil;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Type;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
 import static twitter4jads.TwitterAdsConstants.APP_CTA;
 import static twitter4jads.TwitterAdsConstants.MAX_VIDEO_WEBSITE_CARD_NAME_LENGTH;
 import static twitter4jads.TwitterAdsConstants.MAX_VIDEO_WEBSITE_CARD_TITLE_LENGTH;
+import static twitter4jads.TwitterAdsConstants.PARAM_AS_USER_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_CARD_IDS;
 import static twitter4jads.TwitterAdsConstants.PARAM_COUNT;
 import static twitter4jads.TwitterAdsConstants.PARAM_COUNTRY_CODE;
@@ -92,6 +56,45 @@ import static twitter4jads.TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4;
 import static twitter4jads.TwitterAdsConstants.PREFIX_STATS_ACCOUNTS_URI;
 import static twitter4jads.TwitterAdsConstants.UPLOAD_VIDEO_CARD_IMAGE_URL;
 import static twitter4jads.util.TwitterAdUtil.isNotNullOrEmpty;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.gson.reflect.TypeToken;
+
+import twitter4jads.BaseAdsListResponse;
+import twitter4jads.BaseAdsListResponseIterable;
+import twitter4jads.BaseAdsResponse;
+import twitter4jads.TwitterAdsClient;
+import twitter4jads.TwitterAdsConstants;
+import twitter4jads.api.TwitterAdsCardsApi;
+import twitter4jads.internal.http.HttpParameter;
+import twitter4jads.internal.models4j.Media;
+import twitter4jads.internal.models4j.MediaUpload;
+import twitter4jads.internal.models4j.TwitterException;
+import twitter4jads.models.ads.HttpVerb;
+import twitter4jads.models.ads.TwitterUUIDResponse;
+import twitter4jads.models.ads.cards.AbstractConversationCard;
+import twitter4jads.models.ads.cards.TwitterImageAppDownloadCard;
+import twitter4jads.models.ads.cards.TwitterImageConversationCard;
+import twitter4jads.models.ads.cards.TwitterImageDMCard;
+import twitter4jads.models.ads.cards.TwitterLeadGenerationStat;
+import twitter4jads.models.ads.cards.TwitterMobileAppCard;
+import twitter4jads.models.ads.cards.TwitterVideoAppDownloadCard;
+import twitter4jads.models.ads.cards.TwitterVideoConversationCard;
+import twitter4jads.models.ads.cards.TwitterVideoDMCard;
+import twitter4jads.models.ads.cards.TwitterVideoWebsiteCard;
+import twitter4jads.models.ads.cards.TwitterWebsiteCard;
+import twitter4jads.models.media.TwitterLibraryMedia;
+import twitter4jads.util.TwitterAdUtil;
 
 /**
  * User: abhay
@@ -376,7 +379,8 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
     public BaseAdsResponse<TwitterWebsiteCard> updateWebsiteCard(String accountId, String name, String cardId, String websiteTitle, String websiteUrl, String imageMediaId) throws TwitterException {
         TwitterAdUtil.ensureNotNull(cardId, "Card Id");
 
-        List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle, websiteUrl, imageMediaId);
+        List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle,
+                websiteUrl, imageMediaId, null);
         String url = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 + accountId + PATH_WEBSITE_CARDS + cardId;
         HttpParameter[] parameters = params.toArray(new HttpParameter[params.size()]);
         Type type = new TypeToken<BaseAdsResponse<TwitterWebsiteCard>>() {
@@ -385,8 +389,10 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
     }
 
     @Override
-    public BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle, String websiteUrl, String imageMediaId) throws TwitterException {
-        final List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle, websiteUrl, imageMediaId);
+    public BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle,
+            String websiteUrl, String imageMediaId, String asUserId) throws TwitterException {
+        final List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle,
+                websiteUrl, imageMediaId, asUserId);
         final String url = twitterAdsClient.getBaseAdsAPIUrl() + PREFIX_ACCOUNTS_URI_4 + accountId + PATH_WEBSITE_CARDS;
         final HttpParameter[] parameters = params.toArray(new HttpParameter[params.size()]);
         Type type = new TypeToken<BaseAdsResponse<TwitterWebsiteCard>>() {
@@ -827,7 +833,7 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
     }
 
     private List<HttpParameter> validateAndCreateParamsForCreateWebsiteCard(String accountId, String name, String websiteTitle, String websiteUrl,
-                                                                            String mediaId) throws TwitterException {
+            String mediaId, String asUserId) throws TwitterException {
         TwitterAdUtil.ensureNotNull(accountId, "AccountId");
         TwitterAdUtil.ensureNotNull(name, "Name");
         TwitterAdUtil.ensureNotNull(websiteTitle, "WebsiteTitle");
@@ -840,6 +846,10 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
 
         if (isNotNullOrEmpty(mediaId)) {
             params.add(new HttpParameter(PARAM_IMAGE_MEDIA_ID, mediaId));
+        }
+
+        if (isNotNullOrEmpty(asUserId)) {
+            params.add(new HttpParameter(PARAM_AS_USER_ID, asUserId));
         }
 
         return params;

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsCardsApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsCardsApiImpl.java
@@ -3,7 +3,6 @@ package twitter4jads.impl;
 import static twitter4jads.TwitterAdsConstants.APP_CTA;
 import static twitter4jads.TwitterAdsConstants.MAX_VIDEO_WEBSITE_CARD_NAME_LENGTH;
 import static twitter4jads.TwitterAdsConstants.MAX_VIDEO_WEBSITE_CARD_TITLE_LENGTH;
-import static twitter4jads.TwitterAdsConstants.PARAM_AS_USER_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_CARD_IDS;
 import static twitter4jads.TwitterAdsConstants.PARAM_COUNT;
 import static twitter4jads.TwitterAdsConstants.PARAM_COUNTRY_CODE;
@@ -380,7 +379,7 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
         TwitterAdUtil.ensureNotNull(cardId, "Card Id");
 
         List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle,
-                websiteUrl, imageMediaId, null);
+                websiteUrl, imageMediaId);
         String url = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 + accountId + PATH_WEBSITE_CARDS + cardId;
         HttpParameter[] parameters = params.toArray(new HttpParameter[params.size()]);
         Type type = new TypeToken<BaseAdsResponse<TwitterWebsiteCard>>() {
@@ -390,9 +389,9 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
 
     @Override
     public BaseAdsResponse<TwitterWebsiteCard> createWebsiteCard(String accountId, String name, String websiteTitle,
-            String websiteUrl, String imageMediaId, String asUserId) throws TwitterException {
+            String websiteUrl, String imageMediaId) throws TwitterException {
         final List<HttpParameter> params = validateAndCreateParamsForCreateWebsiteCard(accountId, name, websiteTitle,
-                websiteUrl, imageMediaId, asUserId);
+                websiteUrl, imageMediaId);
         final String url = twitterAdsClient.getBaseAdsAPIUrl() + PREFIX_ACCOUNTS_URI_4 + accountId + PATH_WEBSITE_CARDS;
         final HttpParameter[] parameters = params.toArray(new HttpParameter[params.size()]);
         Type type = new TypeToken<BaseAdsResponse<TwitterWebsiteCard>>() {
@@ -833,7 +832,7 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
     }
 
     private List<HttpParameter> validateAndCreateParamsForCreateWebsiteCard(String accountId, String name, String websiteTitle, String websiteUrl,
-            String mediaId, String asUserId) throws TwitterException {
+            String mediaId) throws TwitterException {
         TwitterAdUtil.ensureNotNull(accountId, "AccountId");
         TwitterAdUtil.ensureNotNull(name, "Name");
         TwitterAdUtil.ensureNotNull(websiteTitle, "WebsiteTitle");
@@ -846,10 +845,6 @@ public class TwitterAdsCardsApiImpl implements TwitterAdsCardsApi {
 
         if (isNotNullOrEmpty(mediaId)) {
             params.add(new HttpParameter(PARAM_IMAGE_MEDIA_ID, mediaId));
-        }
-
-        if (isNotNullOrEmpty(asUserId)) {
-            params.add(new HttpParameter(PARAM_AS_USER_ID, asUserId));
         }
 
         return params;

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsLineItemApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsLineItemApiImpl.java
@@ -1,45 +1,5 @@
 package twitter4jads.impl;
 
-import com.google.common.base.Optional;
-import com.google.gson.reflect.TypeToken;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import twitter4jads.BaseAdsListResponse;
-import twitter4jads.BaseAdsListResponseIterable;
-import twitter4jads.BaseAdsResponse;
-import twitter4jads.TwitterAdsClient;
-import twitter4jads.TwitterAdsConstants;
-import twitter4jads.api.TwitterAdsLineItemApi;
-import twitter4jads.internal.http.HttpParameter;
-import twitter4jads.internal.http.HttpResponse;
-import twitter4jads.internal.models4j.TwitterException;
-import twitter4jads.models.ads.BidType;
-import twitter4jads.models.ads.EntityStatus;
-import twitter4jads.models.ads.HttpVerb;
-import twitter4jads.models.ads.LineItem;
-import twitter4jads.models.ads.LineItemAppResponse;
-import twitter4jads.models.ads.Placement;
-import twitter4jads.models.ads.ProductType;
-import twitter4jads.models.ads.PromotedAccount;
-import twitter4jads.models.ads.Sentiments;
-import twitter4jads.models.ads.TrackingTag;
-import twitter4jads.models.ads.TwitterAdObjective;
-import twitter4jads.models.ads.TwitterOSType;
-import twitter4jads.models.ads.sort.LineItemsSortByField;
-import twitter4jads.models.ads.sort.PromotedAccountsSortByField;
-import twitter4jads.models.media.TwitterMediaCallToAction;
-import twitter4jads.models.video.AssociateMediaCreativeResponse;
-import twitter4jads.models.video.TwitterCallToActionType;
-import twitter4jads.util.TwitterAdUtil;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-
 import static twitter4jads.TwitterAdsConstants.PARAM_ACCOUNT_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_ACCOUNT_MEDIA_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_ADVERTISER_DOMAIN;
@@ -86,6 +46,48 @@ import static twitter4jads.TwitterAdsConstants.PATH_MEDIA_CREATIVES;
 import static twitter4jads.TwitterAdsConstants.PATH_PROMOTED_ACCOUNTS;
 import static twitter4jads.TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4;
 import static twitter4jads.TwitterAdsConstants.PRE_ROLL_CALL_TO_ACTION;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Optional;
+import com.google.gson.reflect.TypeToken;
+
+import twitter4jads.BaseAdsListResponse;
+import twitter4jads.BaseAdsListResponseIterable;
+import twitter4jads.BaseAdsResponse;
+import twitter4jads.TwitterAdsClient;
+import twitter4jads.TwitterAdsConstants;
+import twitter4jads.api.TwitterAdsLineItemApi;
+import twitter4jads.internal.http.HttpParameter;
+import twitter4jads.internal.http.HttpResponse;
+import twitter4jads.internal.models4j.TwitterException;
+import twitter4jads.models.ads.BidType;
+import twitter4jads.models.ads.EntityStatus;
+import twitter4jads.models.ads.HttpVerb;
+import twitter4jads.models.ads.LineItem;
+import twitter4jads.models.ads.LineItemAppResponse;
+import twitter4jads.models.ads.Placement;
+import twitter4jads.models.ads.ProductType;
+import twitter4jads.models.ads.PromotedAccount;
+import twitter4jads.models.ads.Sentiments;
+import twitter4jads.models.ads.TrackingTag;
+import twitter4jads.models.ads.TwitterAdObjective;
+import twitter4jads.models.ads.TwitterOSType;
+import twitter4jads.models.ads.sort.LineItemsSortByField;
+import twitter4jads.models.ads.sort.PromotedAccountsSortByField;
+import twitter4jads.models.media.TwitterMediaCallToAction;
+import twitter4jads.models.video.AssociateMediaCreativeResponse;
+import twitter4jads.models.video.TwitterCallToActionType;
+import twitter4jads.util.TwitterAdUtil;
 
 /**
  * User: abhay
@@ -537,16 +539,15 @@ public class TwitterAdsLineItemApiImpl implements TwitterAdsLineItemApi {
             }
         }
 
-        if (startTime == null || !startTime.isPresent()) {
+        if (startTime != null && startTime.isPresent()) {
             params.add(new HttpParameter(PARAM_START_TIME, String.valueOf(startTime)));
         }
-        if (endTime == null || !endTime.isPresent()) {
+        if (endTime != null && endTime.isPresent()) {
             params.add(new HttpParameter(PARAM_END_TIME, String.valueOf(endTime)));
         }
         if (TwitterAdUtil.isNotNull(budget)) {
             params.add(new HttpParameter(PARAM_TOTAL_BUDGET_AMOUNT_LOCAL_MICRO, budget));
         }
-
 
         if (productType != null && productType.isPresent()) {
             params.add(new HttpParameter(PARAM_PRODUCT_TYPE, productType.get().name()));
@@ -589,10 +590,10 @@ public class TwitterAdsLineItemApiImpl implements TwitterAdsLineItemApi {
         if (TwitterAdUtil.isNotNull(targetCPA)) {
             params.add(new HttpParameter(PARAM_TARGET_CPA_LOCAL_MICRO, targetCPA));
         }
-        if (startTime == null || !startTime.isEmpty()) {
+        if (startTime != null && !startTime.isEmpty()) {
             params.add(new HttpParameter(PARAM_START_TIME, String.valueOf(startTime)));
         }
-        if (endTime == null || !endTime.isEmpty()) {
+        if (endTime != null && !endTime.isEmpty()) {
             params.add(new HttpParameter(PARAM_END_TIME, String.valueOf(endTime)));
         }
 

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsLineItemApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsLineItemApiImpl.java
@@ -4,6 +4,7 @@ import static twitter4jads.TwitterAdsConstants.PARAM_ACCOUNT_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_ACCOUNT_MEDIA_ID;
 import static twitter4jads.TwitterAdsConstants.PARAM_ADVERTISER_DOMAIN;
 import static twitter4jads.TwitterAdsConstants.PARAM_APP_STORE_IDENTIFIER;
+import static twitter4jads.TwitterAdsConstants.PARAM_AUTOMATICALLY_SELECT_BID;
 import static twitter4jads.TwitterAdsConstants.PARAM_BID_AMOUNT_LOCAL_MICRO;
 import static twitter4jads.TwitterAdsConstants.PARAM_BID_TYPE;
 import static twitter4jads.TwitterAdsConstants.PARAM_BID_UNIT;
@@ -484,7 +485,10 @@ public class TwitterAdsLineItemApiImpl implements TwitterAdsLineItemApi {
         if (campaignId != null && campaignId.isPresent()) {
             params.add(new HttpParameter(PARAM_CAMPAIGN_ID, campaignId.get()));
         }
-        if (TwitterAdUtil.isNotNull(bidAmountLocalMicro) && bidAmountLocalMicro.isPresent()) {
+
+        if (automaticallySelectBid) {
+            params.add(new HttpParameter(PARAM_AUTOMATICALLY_SELECT_BID, automaticallySelectBid));
+        } else if (TwitterAdUtil.isNotNull(bidAmountLocalMicro) && bidAmountLocalMicro.isPresent()) {
             params.add(new HttpParameter(PARAM_BID_AMOUNT_LOCAL_MICRO, bidAmountLocalMicro.get()));
             if (bidType != null) {
                 params.add(new HttpParameter(PARAM_BID_TYPE, bidType.name()));

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
@@ -39,7 +39,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
             throws TwitterException {
 
         List<HttpParameter> parameterList =
-                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, cardId, twitterPreviewTarget, videoKey);
+                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, twitterPreviewTarget, videoKey);
 
         String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 +
                 accountId + TwitterAdsConstants.TWEET_PATH_PREVIEW;
@@ -80,7 +80,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
 
     //-------------------------------------------------------------- PRIVATE METHODS-------------------------------------------------------------//
 
-    private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds, String cardId,
+    private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds,
                                                                                   TwitterPreviewTarget twitterPreviewTarget, String videoId)
         throws TwitterException {
         final boolean isPreviewTargetPublisherNetwork = twitterPreviewTarget == PUBLISHER_NETWORK;
@@ -101,9 +101,6 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
         }
         if (TwitterAdUtil.isNotNullOrEmpty(mediaIdsCsv)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_MEDIA_IDS, mediaIdsCsv));
-        }
-        if (TwitterAdUtil.isNotNullOrEmpty(cardId)) {
-            parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_CARD_ID, cardId));
         }
         if (TwitterAdUtil.isNotNullOrEmpty(videoId)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_VIDEO_ID, videoId));

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
@@ -1,7 +1,14 @@
 package twitter4jads.impl;
 
+import static twitter4jads.models.ads.TwitterPreviewTarget.PUBLISHER_NETWORK;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
 import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
+
 import twitter4jads.BaseAdsListResponse;
 import twitter4jads.TwitterAdsClient;
 import twitter4jads.TwitterAdsConstants;
@@ -12,12 +19,6 @@ import twitter4jads.internal.models4j.TwitterException;
 import twitter4jads.models.ads.TwitterCreativePreview;
 import twitter4jads.models.ads.TwitterPreviewTarget;
 import twitter4jads.util.TwitterAdUtil;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.List;
-
-import static twitter4jads.models.ads.TwitterPreviewTarget.PUBLISHER_NETWORK;
 
 /**
  * User: abhishek.chatrath
@@ -39,7 +40,8 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
             throws TwitterException {
 
         List<HttpParameter> parameterList =
-                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, twitterPreviewTarget, videoKey);
+                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, cardId,
+                        twitterPreviewTarget, videoKey);
 
         String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 +
                 accountId + TwitterAdsConstants.TWEET_PATH_PREVIEW;
@@ -81,7 +83,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
     //-------------------------------------------------------------- PRIVATE METHODS-------------------------------------------------------------//
 
     private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds,
-                                                                                  TwitterPreviewTarget twitterPreviewTarget, String videoId)
+            String cardId, TwitterPreviewTarget twitterPreviewTarget, String videoId)
         throws TwitterException {
         final boolean isPreviewTargetPublisherNetwork = twitterPreviewTarget == PUBLISHER_NETWORK;
         final String mediaIdsCsv = TwitterAdUtil.getCsv(mediaIds);
@@ -104,6 +106,9 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
         }
         if (TwitterAdUtil.isNotNullOrEmpty(videoId)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_VIDEO_ID, videoId));
+        }
+        if (TwitterAdUtil.isNotNullOrEmpty(cardId)) {
+            parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_CARD_ID, cardId));
         }
 
         return parameterList;

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
@@ -40,8 +40,8 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
             throws TwitterException {
 
         List<HttpParameter> parameterList =
-                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, cardId,
-                        twitterPreviewTarget, videoKey);
+                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, twitterPreviewTarget,
+                        videoKey);
 
         String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 +
                 accountId + TwitterAdsConstants.TWEET_PATH_PREVIEW;
@@ -83,7 +83,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
     //-------------------------------------------------------------- PRIVATE METHODS-------------------------------------------------------------//
 
     private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds,
-            String cardId, TwitterPreviewTarget twitterPreviewTarget, String videoId)
+            TwitterPreviewTarget twitterPreviewTarget, String videoId)
         throws TwitterException {
         final boolean isPreviewTargetPublisherNetwork = twitterPreviewTarget == PUBLISHER_NETWORK;
         final String mediaIdsCsv = TwitterAdUtil.getCsv(mediaIds);
@@ -106,9 +106,6 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
         }
         if (TwitterAdUtil.isNotNullOrEmpty(videoId)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_VIDEO_ID, videoId));
-        }
-        if (TwitterAdUtil.isNotNullOrEmpty(cardId)) {
-            parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_CARD_ID, cardId));
         }
 
         return parameterList;

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsPreviewApiImpl.java
@@ -39,7 +39,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
             throws TwitterException {
 
         List<HttpParameter> parameterList =
-                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, twitterPreviewTarget, videoKey);
+                validateAndGetParametersForUnpublishedPostPreview(text, asUserId, mediaIds, cardId, twitterPreviewTarget, videoKey);
 
         String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4 +
                 accountId + TwitterAdsConstants.TWEET_PATH_PREVIEW;
@@ -80,7 +80,7 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
 
     //-------------------------------------------------------------- PRIVATE METHODS-------------------------------------------------------------//
 
-    private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds,
+    private List<HttpParameter> validateAndGetParametersForUnpublishedPostPreview(String text, String asUserId, List<String> mediaIds, String cardId,
                                                                                   TwitterPreviewTarget twitterPreviewTarget, String videoId)
         throws TwitterException {
         final boolean isPreviewTargetPublisherNetwork = twitterPreviewTarget == PUBLISHER_NETWORK;
@@ -101,6 +101,9 @@ public class TwitterAdsPreviewApiImpl implements TwitterAdsPreviewApi {
         }
         if (TwitterAdUtil.isNotNullOrEmpty(mediaIdsCsv)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_MEDIA_IDS, mediaIdsCsv));
+        }
+        if (TwitterAdUtil.isNotNullOrEmpty(cardId)) {
+            parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_CARD_ID, cardId));
         }
         if (TwitterAdUtil.isNotNullOrEmpty(videoId)) {
             parameterList.add(new HttpParameter(TwitterAdsConstants.PARAM_VIDEO_ID, videoId));

--- a/twitter4j-ads/src/twitter4jads/impl/TwitterAdsTargetingApiImpl.java
+++ b/twitter4j-ads/src/twitter4jads/impl/TwitterAdsTargetingApiImpl.java
@@ -1,52 +1,5 @@
 package twitter4jads.impl;
 
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import org.apache.commons.lang3.StringUtils;
-import twitter4jads.BaseAdsListResponse;
-import twitter4jads.BaseAdsListResponseIterable;
-import twitter4jads.BaseAdsResponse;
-import twitter4jads.TwitterAdsClient;
-import twitter4jads.TwitterAdsConstants;
-import twitter4jads.api.TwitterAdsTargetingApi;
-import twitter4jads.internal.http.HttpParameter;
-import twitter4jads.internal.http.HttpResponse;
-import twitter4jads.internal.models4j.TwitterException;
-import twitter4jads.models.LocationType;
-import twitter4jads.models.ads.AppStoreSearchType;
-import twitter4jads.models.ads.BidType;
-import twitter4jads.models.ads.Conversations;
-import twitter4jads.models.ads.Devices;
-import twitter4jads.models.ads.HttpVerb;
-import twitter4jads.models.ads.IabCategory;
-import twitter4jads.models.ads.NewTwitterReachEstimate;
-import twitter4jads.models.ads.PlatformVersions;
-import twitter4jads.models.ads.ProductType;
-import twitter4jads.models.ads.SuggestionType;
-import twitter4jads.models.ads.TargetingCriteria;
-import twitter4jads.models.ads.TargetingLocation;
-import twitter4jads.models.ads.TargetingSuggestion;
-import twitter4jads.models.ads.TargetingType;
-import twitter4jads.models.ads.TwitterAppStore;
-import twitter4jads.models.ads.TwitterApplicationDetails;
-import twitter4jads.models.ads.TwitterBehavior;
-import twitter4jads.models.ads.TwitterBehaviorTaxonomy;
-import twitter4jads.models.ads.audience.TailoredAudienceType;
-import twitter4jads.models.ads.tags.TwitterApplicationList;
-import twitter4jads.models.ads.targeting.TargetingParamRequest;
-import twitter4jads.models.ads.targeting.TargetingParamResponse;
-import twitter4jads.util.TwitterAdUtil;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import static twitter4jads.TwitterAdsConstants.BID_AMOUNT_LOCAL_MICRO;
 import static twitter4jads.TwitterAdsConstants.BID_TYPE;
 import static twitter4jads.TwitterAdsConstants.CAMPAIGN_DAILY_BUDGET_AMOUNT_LOCAL_MICRO;
@@ -108,7 +61,6 @@ import static twitter4jads.TwitterAdsConstants.PARAM_UNORDERED_KEYWORDS;
 import static twitter4jads.TwitterAdsConstants.PARAM_USER_ENGAGEMENT;
 import static twitter4jads.TwitterAdsConstants.PARAM_WIFI_ONLY;
 import static twitter4jads.TwitterAdsConstants.PARAM_WITH_DELETED;
-import static twitter4jads.TwitterAdsConstants.PATH_ACCOUNTS;
 import static twitter4jads.TwitterAdsConstants.PATH_APP_LIST;
 import static twitter4jads.TwitterAdsConstants.PATH_BEHAVIORS;
 import static twitter4jads.TwitterAdsConstants.PATH_BEHAVIORS_TAXONOMY;
@@ -133,6 +85,55 @@ import static twitter4jads.TwitterAdsConstants.PATH_TV_SHOWS;
 import static twitter4jads.TwitterAdsConstants.PREFIX_ACCOUNTS_URI_4;
 import static twitter4jads.TwitterAdsConstants.PREFIX_BATCH_ACCOUNTS_V4;
 import static twitter4jads.util.TwitterAdUtil.constructBaseAdsListResponse;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import twitter4jads.BaseAdsListResponse;
+import twitter4jads.BaseAdsListResponseIterable;
+import twitter4jads.BaseAdsResponse;
+import twitter4jads.TwitterAdsClient;
+import twitter4jads.TwitterAdsConstants;
+import twitter4jads.api.TwitterAdsTargetingApi;
+import twitter4jads.internal.http.HttpParameter;
+import twitter4jads.internal.http.HttpResponse;
+import twitter4jads.internal.models4j.TwitterException;
+import twitter4jads.models.LocationType;
+import twitter4jads.models.ads.AppStoreSearchType;
+import twitter4jads.models.ads.BidType;
+import twitter4jads.models.ads.Conversations;
+import twitter4jads.models.ads.Devices;
+import twitter4jads.models.ads.HttpVerb;
+import twitter4jads.models.ads.IabCategory;
+import twitter4jads.models.ads.NewTwitterReachEstimate;
+import twitter4jads.models.ads.PlatformVersions;
+import twitter4jads.models.ads.ProductType;
+import twitter4jads.models.ads.SuggestionType;
+import twitter4jads.models.ads.TargetingCriteria;
+import twitter4jads.models.ads.TargetingLocation;
+import twitter4jads.models.ads.TargetingSuggestion;
+import twitter4jads.models.ads.TargetingType;
+import twitter4jads.models.ads.TwitterAppStore;
+import twitter4jads.models.ads.TwitterApplicationDetails;
+import twitter4jads.models.ads.TwitterBehavior;
+import twitter4jads.models.ads.TwitterBehaviorTaxonomy;
+import twitter4jads.models.ads.audience.TailoredAudienceType;
+import twitter4jads.models.ads.tags.TwitterApplicationList;
+import twitter4jads.models.ads.targeting.TargetingParamRequest;
+import twitter4jads.models.ads.targeting.TargetingParamResponse;
+import twitter4jads.util.TwitterAdUtil;
 
 /**
  * User: abhay
@@ -364,7 +365,8 @@ public class TwitterAdsTargetingApiImpl implements TwitterAdsTargetingApi {
     public TargetingParamResponse createTargetingBatchRequest(String accountId, List<TargetingParamRequest> targetingParamRequests) throws TwitterException {
         validateTargetingBatch(targetingParamRequests);
 
-        String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + PREFIX_BATCH_ACCOUNTS_V4 + PATH_ACCOUNTS + accountId + PATH_TARGETING_CRITERIA;
+        String baseUrl = twitterAdsClient.getBaseAdsAPIUrl() + PREFIX_BATCH_ACCOUNTS_V4 + accountId
+                + PATH_TARGETING_CRITERIA;
         HttpResponse httpResponse = twitterAdsClient.postBatchRequest(baseUrl, GSON.toJson(targetingParamRequests));
         Type typeToken = new TypeToken<TargetingParamResponse>() {
         }.getType();

--- a/twitter4j-ads/src/twitter4jads/internal/models4j/TwitterImpl.java
+++ b/twitter4j-ads/src/twitter4jads/internal/models4j/TwitterImpl.java
@@ -17,16 +17,6 @@
 
 package twitter4jads.internal.models4j;
 
-import org.apache.commons.lang3.StringUtils;
-import org.codehaus.jackson.map.ObjectMapper;
-import twitter4jads.auth.Authorization;
-import twitter4jads.conf.Configuration;
-import twitter4jads.internal.http.HttpParameter;
-import twitter4jads.internal.http.HttpResponse;
-import twitter4jads.internal.json.TwitterUploadMediaResponseImpl;
-import twitter4jads.internal.util.z_T4JInternalStringUtil;
-import twitter4jads.util.TwitterAdUtil;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,6 +28,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import twitter4jads.auth.Authorization;
+import twitter4jads.conf.Configuration;
+import twitter4jads.internal.http.HttpParameter;
+import twitter4jads.internal.http.HttpResponse;
+import twitter4jads.internal.json.TwitterUploadMediaResponseImpl;
+import twitter4jads.internal.util.z_T4JInternalStringUtil;
+import twitter4jads.util.TwitterAdUtil;
 
 /**
  * A java representation of the <a href="https://dev.twitter.com/docs/api">Twitter REST API</a><br>
@@ -81,19 +82,19 @@ public class TwitterImpl extends TwitterBaseImpl implements Twitter {
         HttpParameter[] implicitParams = implicitParamsMap.get(conf);
         String implicitParamsStr = implicitParamsStrMap.get(conf);
         if (implicitParams == null) {
-            String includeEntities = conf.isIncludeEntitiesEnabled() ? "1" : "0";
-            String includeRTs = conf.isIncludeRTsEnabled() ? "1" : "0";
-            boolean contributorsEnabled = conf.getContributingTo() != -1L;
-            implicitParamsStr = "include_entities=" + includeEntities + "&include_rts=" + includeRTs +
-                                (contributorsEnabled ? "&contributingto=" + conf.getContributingTo() : "");
-            implicitParamsStrMap.put(conf, implicitParamsStr);
+//            String includeEntities = conf.isIncludeEntitiesEnabled() ? "1" : "0";
+//            String includeRTs = conf.isIncludeRTsEnabled() ? "1" : "0";
+//            boolean contributorsEnabled = conf.getContributingTo() != -1L;
+//            implicitParamsStr = "include_entities=" + includeEntities + "&include_rts=" + includeRTs +
+//                                (contributorsEnabled ? "&contributingto=" + conf.getContributingTo() : "");
+//            implicitParamsStrMap.put(conf, implicitParamsStr);
 
             List<HttpParameter> params = new ArrayList<HttpParameter>();
-            params.add(new HttpParameter("include_entities", includeEntities));
-            params.add(new HttpParameter("include_rts", includeRTs));
-            if (contributorsEnabled) {
-                params.add(new HttpParameter("contributingto", conf.getContributingTo()));
-            }
+//            params.add(new HttpParameter("include_entities", includeEntities));
+//            params.add(new HttpParameter("include_rts", includeRTs));
+//            if (contributorsEnabled) {
+//                params.add(new HttpParameter("contributingto", conf.getContributingTo()));
+//            }
             implicitParams = params.toArray(new HttpParameter[params.size()]);
             implicitParamsMap.put(conf, implicitParams);
         }


### PR DESCRIPTION
Hi!
I've recognized that the operation "TwitterAdsMediaUploadApi#uploadMediaAndGetMediaId" is not working, as the built URL contains the API version twice (.../1.1/1.1/media/...). This Pull requests contains a fix that works fine for me.
Cheers,
Andreas