### PR TITLE
Fixed upload media url

### DIFF
--- a/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
+++ b/twitter4j-ads/src/twitter4jads/TwitterAdsConstants.java
@@ -15,7 +15,8 @@ public interface TwitterAdsConstants {
     int TAILORED_AUDIENCE_UPDATE_BATCH_SIZE = 2500;
 
     String TWEET_PREVIEW_PATH = "/tweet/preview/";
-    String UPLOAD_MEDIA_URL = "1.1/media/";
+
+    String UPLOAD_MEDIA_URL = "media/";
     String UPLOAD_JSON = "upload.json";
     String PREFIX_BATCH_ACCOUNTS_V4 = "4/batch/accounts/";
     String V4_PREFIX_STATS_JOB_ACCOUNTS_URI = "4/stats/jobs/accounts/";


### PR DESCRIPTION
Hi!
I've recognized that the operation "TwitterAdsMediaUploadApi#uploadMediaAndGetMediaId" is not working, as the built URL contains the API version twice (.../1.1/1.1/media/...). This Pull requests contains a fix that works fine for me.
Cheers,
Andreas